### PR TITLE
ci: add job to check for signed-off-by tags

### DIFF
--- a/.github/workflows/sob.yml
+++ b/.github/workflows/sob.yml
@@ -1,0 +1,9 @@
+name: DCO
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  dco-check:
+    uses: cncf/dcochecker/.github/workflows/dco.yml@main


### PR DESCRIPTION
As per the contributing documentation DCO/SoB is required.

Looking at the existing Github Actions, nearly all of them are based on node12, which is deprecated and will be removed shortly. So opt for the one that doesn't suffer that issue - cncf/dcochecker